### PR TITLE
Remove TAVILY_API_KEY secret reference from chat-app deployment

### DIFF
--- a/core/chat-app/config/200-deployment.yaml
+++ b/core/chat-app/config/200-deployment.yaml
@@ -23,11 +23,6 @@ spec:
                 secretKeyRef:
                   key: OPENAI_API_KEY
                   name: chat-app-credentials
-            - name: TAVILY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: TAVILY_API_KEY
-                  name: chat-app-credentials
             - name: IN_KUBERNETES
               value: "true" 
           image: quay.io/cali0707/chat-app 


### PR DESCRIPTION
I could not deploy the `chat-app`, and the deployment was stuck, with this:

```
  Normal   Pulling    7s (x3 over 26s)  kubelet            Pulling image "quay.io/cali0707/chat-app"
  Warning  Failed     6s (x3 over 20s)  kubelet            Error: couldn't find key TAVILY_API_KEY in Secret default/chat-app-credentials
```

After adding an `TAVILY_API_KEY` it was fine.