### PR TITLE
update install script to install into openshift and non default namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The prototype is (hopefully) easy to set up and use - you should be able to get 
    1. Edit `core/chat-app/config/100-chat-app-credentials.secret.yaml` to include your api key
 1. Ensure that Knative Functions is installed on your machine. For installation instructions, see [here](https://knative.dev/docs/functions/install-func/)
 1. With your credentials set up so that `kubectl` has access to a running cluster, run `./hack/install.sh`. If you do not already have Knative Serving and Eventing
-   installed in your cluster, you can instead run `FULL_INSTALL=true ./hack/install.sh`
+   installed in your cluster, you can instead run `FULL_INSTALL=true ./hack/install.sh`. To configure which namespace the chat app resources are installed into,
+   set the `CHAT_NAMESPACE` environment variable. If you are installing in openshift, please set `OPENSHIFT=true`.
 
 You will now have a cluster with everything installed and working! If anything did not work in this process, please open a GitHub issue. 
 

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -4,6 +4,10 @@ function wait_for_deployments() {
 	kubectl wait deployment --all --timeout=-1s --for=condition=Available -n "$1"
 }
 
+if [[ -z $CHAT_NAMESPACE ]]; then
+	export CHAT_NAMESPACE=default
+fi
+
 if [[ $FULL_INSTALL ]]; then
 	kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.14.1/serving-crds.yaml
 	kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.14.1/serving-core.yaml
@@ -23,10 +27,14 @@ if [[ $FULL_INSTALL ]]; then
 	wait_for_deployments "knative-eventing"
 fi
 
-(cd tools/resource-cost-calculator && func deploy)
-(cd tools/average-resource-consumption && func deploy)
+(cd tools/resource-cost-calculator && func deploy -n $CHAT_NAMESPACE)
+(cd tools/average-resource-consumption && func deploy -n $CHAT_NAMESPACE)
 
-(cd core/request-proxy && ko apply -f ./config)
-kubectl apply -f ./core/chat-app/config
+(cd core/request-proxy && ko apply -f ./config -- -n $CHAT_NAMESPACE)
+kubectl apply -f ./core/chat-app/config -n $CHAT_NAMESPACE
 
-wait_for_deployments "default"
+if [[ $OPENSHIFT ]]; then
+	kubectl apply -f ./core/chat-app/config/openshift
+fi
+
+wait_for_deployments $CHAT_NAMESPACE

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -8,6 +8,12 @@ if [[ -z $CHAT_NAMESPACE ]]; then
 	export CHAT_NAMESPACE=default
 fi
 
+if [[ $OPENSHIFT ]]; then
+	func_args=("-b=s2i" "--build")
+else
+	func_args=()
+fi
+
 if [[ $FULL_INSTALL ]]; then
 	kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.14.1/serving-crds.yaml
 	kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.14.1/serving-core.yaml
@@ -27,8 +33,8 @@ if [[ $FULL_INSTALL ]]; then
 	wait_for_deployments "knative-eventing"
 fi
 
-(cd tools/resource-cost-calculator && func deploy -n $CHAT_NAMESPACE)
-(cd tools/average-resource-consumption && func deploy -n $CHAT_NAMESPACE)
+(cd tools/resource-cost-calculator && func deploy -n $CHAT_NAMESPACE "${func_args[@]}")
+(cd tools/average-resource-consumption && func deploy -n $CHAT_NAMESPACE "${func_args[@]}")
 
 (cd core/request-proxy && ko apply -f ./config -- -n $CHAT_NAMESPACE)
 kubectl apply -f ./core/chat-app/config -n $CHAT_NAMESPACE


### PR DESCRIPTION
From #10, there were a few issues with installing into openshift:
1. Need to use s2i builder
2. Need to have a route
3. Need to deploy into a non default namespace
This PR should add options for this into the deploy script