### PR TITLE
make resource cost calculations harder for LLM

### DIFF
--- a/tools/average-resource-consumption/func.yaml
+++ b/tools/average-resource-consumption/func.yaml
@@ -9,7 +9,7 @@ build:
   builder: pack
 deploy:
   namespace: default
-  image: quay.io/cali0707/average-resource-consumption@sha256:c18f42d15ec1436982b9e7c5faf5c99716ab1360645296ac86d1e7c45703f3d2
+  image: quay.io/cali0707/average-resource-consumption@sha256:310b968a27e8ff3c750ca69da3b021ab1322629e169ffa1c93be382e99fa6633
   subscriptions:
   - source: chat-broker
     filters:

--- a/tools/average-resource-consumption/handle.go
+++ b/tools/average-resource-consumption/handle.go
@@ -23,10 +23,10 @@ type AverageResourceConsumption struct {
 func Handle(ctx context.Context, e event.Event) (*event.Event, error) {
 	fmt.Printf("Received a new event\n%s", e.String())
 	mockData := []AverageResourceConsumption{
-		{CPU: ResourceConsumptionMetric{Value: 2, Unit: "Cores"}, Memory: ResourceConsumptionMetric{Value: 8200, Unit: "MiB"}, Month: "March"},
-		{CPU: ResourceConsumptionMetric{Value: 2.5, Unit: "Cores"}, Memory: ResourceConsumptionMetric{Value: 8117, Unit: "MiB"}, Month: "April"},
-		{CPU: ResourceConsumptionMetric{Value: 3.5, Unit: "Cores"}, Memory: ResourceConsumptionMetric{Value: 9217, Unit: "MiB"}, Month: "May"},
-		{CPU: ResourceConsumptionMetric{Value: 4.5, Unit: "Cores"}, Memory: ResourceConsumptionMetric{Value: 10117, Unit: "MiB"}, Month: "June"},
+		{CPU: ResourceConsumptionMetric{Value: 21.33, Unit: "Cores"}, Memory: ResourceConsumptionMetric{Value: 8200, Unit: "MiB"}, Month: "March"},
+		{CPU: ResourceConsumptionMetric{Value: 27.56, Unit: "Cores"}, Memory: ResourceConsumptionMetric{Value: 8117, Unit: "MiB"}, Month: "April"},
+		{CPU: ResourceConsumptionMetric{Value: 33.17, Unit: "Cores"}, Memory: ResourceConsumptionMetric{Value: 9217, Unit: "MiB"}, Month: "May"},
+		{CPU: ResourceConsumptionMetric{Value: 34.51, Unit: "Cores"}, Memory: ResourceConsumptionMetric{Value: 10117, Unit: "MiB"}, Month: "June"},
 	}
 
 	response := event.New()

--- a/tools/resource-cost-calculator/func.yaml
+++ b/tools/resource-cost-calculator/func.yaml
@@ -9,7 +9,7 @@ build:
   builder: pack
 deploy:
   namespace: default
-  image: quay.io/cali0707/resource-cost-calculator@sha256:d0c71347d3df508320ddb96355ce61e58645797febd8f9f9324f9638ffbd3205
+  image: quay.io/cali0707/resource-cost-calculator@sha256:9cb1f997faf9f191485772ee8a0ed3d478e57be1942aad5c821ffbc725010e2a
   subscriptions:
   - source: chat-broker
     filters:

--- a/tools/resource-cost-calculator/handle.go
+++ b/tools/resource-cost-calculator/handle.go
@@ -10,8 +10,8 @@ import (
 )
 
 var usageCosts map[string]map[string]float64 = map[string]map[string]float64{
-	"cpu":    {"cores": 12.5},
-	"memory": {"mib": 0.01, "gib": 10.24},
+	"cpu":    {"cores": 12.99},
+	"memory": {"mib": 0.016, "gib": 16.384},
 }
 
 type ResourceCostRequest struct {


### PR DESCRIPTION
While playing around with the demo, I realized that with our simple numbers for usage and cost the LLM was generally able to get the math for the resource calculation correct on it's own without using the tools. This PR makes the numbers harder so that we can show how tools help prevent LLM hallucinations.